### PR TITLE
AB-6083-fix-textField-cursor-jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - TextField empty state bug
 - Positioning of the menu dropdown by using popper JS
+- Fixed cursor jumping to the end when using controlled TextField
 
 ## 1.0.0 - 06-09-2020
 

--- a/src/components/TextField/TextField.js
+++ b/src/components/TextField/TextField.js
@@ -45,6 +45,7 @@ const TextField = React.forwardRef((props, ref) => {
   const [active, setActive] = useState(false)
   const [anchorElement, setAnchorElement] = useState(null)
   const textFieldRef = useRef({})
+  const cursorRef = useRef({})
   const inputRef = useCombinedRefs(useRef({}), ref)
 
   useClickOutsideListener(() => {
@@ -88,12 +89,23 @@ const TextField = React.forwardRef((props, ref) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [otherProps.value])
 
+  useEffect(() => {
+    const { caretStart, caretEnd } = cursorRef.current
+    if (type !== types.options && caretStart && inputRef && inputRef.current) {
+      inputRef.current.setSelectionRange(caretStart, caretEnd)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+
   const onInputChange = e => {
     e.persist()
     const {
       target: { value },
     } = e
     setEmpty(!value)
+    const caretStart = e.target.selectionStart
+    const caretEnd = e.target.selectionEnd
+    cursorRef.current = { caretStart, caretEnd }
     onChange(e)
   }
 


### PR DESCRIPTION
relevant discussion https://github.com/facebook/react/issues/14904
## What I did
preserved the input cursor
## How to test
check storybook TextField with value

### Checklist
- [ ] Does this need a new/update storybook example?
- [ ] Does this need new/update tests?

- [ ] run eslint
- [ ] run test
- [ ] run build

If your answer is yes to any of these, please make sure to include it in your PR.

> NOTE: Please submit all PRs to the `development` branch.
