### PR TITLE
Added webkit-autofill to fix google-help auto complete bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@
 - Add no results message to table
 - Added `classes` prop to `<DialogWizard/>`
 - New `<Tabs/>` component
-- Fixed Google auto-complete bug
+- Added -webkit-auto-fill in InputBase 
 
 ## 1.0.0 - 06-09-2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Add no results message to table
 - Added `classes` prop to `<DialogWizard/>`
 - New `<Tabs/>` component
+- Fixed Google auto-complete bug
 
 ## 1.0.0 - 06-09-2020
 

--- a/src/components/InputBase/InputBase.module.scss
+++ b/src/components/InputBase/InputBase.module.scss
@@ -32,6 +32,11 @@
       color: av-color(content);
       opacity: av-opacity(medium);
     }
+
+    &:-webkit-autofill {
+      -webkit-text-fill-color: av-color(content);
+      caret-color: av-color(content);
+    }
   }
 
   > textarea {


### PR DESCRIPTION
## What I did

## How to test
You can copy paste in Login.scss in better-tommorow-webui and see that bug is fixed.

input:-webkit-autofill {
    -webkit-text-fill-color: av-color(content);
    caret-color: av-color(content);
  }

### Checklist
- [ ] Does this need a new/update storybook example?
- [ ] Does this need new/update tests?

- [ ] run eslint
- [ ] run test
- [ ] run build

If your answer is yes to any of these, please make sure to include it in your PR.

> NOTE: Please submit all PRs to the `development` branch.
