### PR TITLE
BTTRIBEV2-11339-allow-selected-keys-to-update-tree-when-is-not-passed-on-mount

### DIFF
--- a/src/components/Tree/useFlattenTreeData/useFlattenTreeData.js
+++ b/src/components/Tree/useFlattenTreeData/useFlattenTreeData.js
@@ -4,6 +4,7 @@ import { ALL_ROOTS_COMBINED_KEY } from '../utils'
 const useFlattenTreeData = ({ data, selectedKeys = [], maxNestingLevel }) => {
   const [flattenedNodes, setFlattenedNodes] = useState({})
   const nodeKeysMap = useRef(new Map())
+  const isSelectedKeysUpdatedAfterMount = useRef(false)
 
   const flatten = useCallback(
     (treeData, nodesMap, selectedKeysSet = new Set(), layer = 0) => {
@@ -116,6 +117,18 @@ const useFlattenTreeData = ({ data, selectedKeys = [], maxNestingLevel }) => {
     [flatten],
   )
 
+  const handleSetSelectedNodesFromKeysArr = useCallback(
+    selectedKeysArr => {
+      if (!Object.keys(flattenedNodes).length) return
+      selectedKeysArr.forEach(
+        key =>
+          (flattenedNodes[key] = { ...flattenedNodes[key], isSelected: true }),
+      )
+      calculateAmountOfSelectedNodesAndChildren(ALL_ROOTS_COMBINED_KEY, true)
+    },
+    [calculateAmountOfSelectedNodesAndChildren, flattenedNodes],
+  )
+
   const flattenTreeData = useCallback(
     (treeData, selectedKeysSet, layer = 0) => {
       const flattenedNodesMap = {}
@@ -135,6 +148,13 @@ const useFlattenTreeData = ({ data, selectedKeys = [], maxNestingLevel }) => {
     flattenTreeData(data, new Set(selectedKeys))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data])
+
+  useEffect(() => {
+    if (!isSelectedKeysUpdatedAfterMount.current && selectedKeys.length) {
+      isSelectedKeysUpdatedAfterMount.current = true
+      handleSetSelectedNodesFromKeysArr(selectedKeys)
+    }
+  }, [handleSetSelectedNodesFromKeysArr, selectedKeys])
 
   return {
     flattenedNodes,


### PR DESCRIPTION
Added functionality that will enable selectedKeys to update the tree when a selectedKeys array is not passed on the first render but is passed after some renders.


### Checklist
- [ ] Does this need a new/update storybook example?
- [ ] Does this need new/update tests?

- [ ] run eslint
- [ ] run test
- [ ] run build

If your answer is yes to any of these, please make sure to include it in your PR.

> NOTE: Please submit all PRs to the `development` branch.
